### PR TITLE
Include LD reference panel in bulk download

### DIFF
--- a/app.R
+++ b/app.R
@@ -673,7 +673,7 @@ server <- function(input, output, session) {
       merged_DT <- lapply(1:nrow(dat_paths), function(i){
         ROW <- dat_paths[i,]
         dat <- data.table::fread(ROW$file_path, nThread = 1)
-        dat <- cbind(study=ROW$study, ROW$study_type, dat)
+        dat <- cbind(study=ROW$study, study_type=ROW$study_type, LD_ref=ROW$LD_ref, dat)
         incProgress(1/nrow(dat_paths), detail = paste(round(i/nrow(dat_paths),2)*100,"%"))
         return(dat)
       }) %>% data.table::rbindlist(fill = T)


### PR DESCRIPTION
When I bulk downloaded the data\*, I noticed that for the BST1 locus that there were 2 rows per SNP, and the only column that differed was `MAF`. This PR includes the column `LD_ref` to distinguish between the 2 rows.

Related questions:

1. How is the `Freq` column calculated? I was surprised that it is unchanged when using different LD panels. Is `MAF` calculated in the reference panel and `Freq` calculated in the study samples?

2. Is there a documentation page that describes each of the output columns in detail? I haven't been able to find it.

\* Caveat: I didn't actually perform the bulk download from within the app. It always crashed at 87%. I extracted the code from `app.R` to combine all the results.